### PR TITLE
development release :: v0.0.1-alpha.0 candidate

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/JesseCoretta/go-antlraci
 go 1.20
 
 require (
-	github.com/JesseCoretta/go-stackage v0.0.3-alpha.0.0.20230917063119-c5b1c11b1112 // indirect
+	github.com/JesseCoretta/go-stackage v0.0.3-alpha.0.0.20230917071832-d54179314634 // indirect
 	github.com/antlr4-go/antlr/v4 v4.13.0 // indirect
 	golang.org/x/exp v0.0.0-20230515195305-f3d0a9c9a5cc // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/JesseCoretta/go-antlraci
 go 1.20
 
 require (
-	github.com/JesseCoretta/go-stackage v0.0.3-alpha.0 // indirect
+	github.com/JesseCoretta/go-stackage v0.0.3-alpha.0.0.20230915085653-806fd28c0132 // indirect
 	github.com/antlr4-go/antlr/v4 v4.13.0 // indirect
 	golang.org/x/exp v0.0.0-20230515195305-f3d0a9c9a5cc // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/JesseCoretta/go-antlraci
 go 1.20
 
 require (
-	github.com/JesseCoretta/go-stackage v0.0.3-alpha.0.0.20230915085653-806fd28c0132 // indirect
+	github.com/JesseCoretta/go-stackage v0.0.3-alpha.0.0.20230917063119-c5b1c11b1112 // indirect
 	github.com/antlr4-go/antlr/v4 v4.13.0 // indirect
 	golang.org/x/exp v0.0.0-20230515195305-f3d0a9c9a5cc // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -16,6 +16,8 @@ github.com/JesseCoretta/go-stackage v0.0.3-alpha.0.0.20230915073156-fa22d029b913
 github.com/JesseCoretta/go-stackage v0.0.3-alpha.0.0.20230915073156-fa22d029b913/go.mod h1:x+xxD8I9N7JVURFrjQvLlQAp3AI30egZm7PogZCzB/g=
 github.com/JesseCoretta/go-stackage v0.0.3-alpha.0.0.20230915085653-806fd28c0132 h1:iuTYrRwLCeMRZo/wcMyowdpw1buNWExFd6Dt0dAcR18=
 github.com/JesseCoretta/go-stackage v0.0.3-alpha.0.0.20230915085653-806fd28c0132/go.mod h1:x+xxD8I9N7JVURFrjQvLlQAp3AI30egZm7PogZCzB/g=
+github.com/JesseCoretta/go-stackage v0.0.3-alpha.0.0.20230917063119-c5b1c11b1112 h1:Mm/l++4qytP8gidOwlKRh+u9wviKFR0nI3wU2IS60cg=
+github.com/JesseCoretta/go-stackage v0.0.3-alpha.0.0.20230917063119-c5b1c11b1112/go.mod h1:x+xxD8I9N7JVURFrjQvLlQAp3AI30egZm7PogZCzB/g=
 github.com/antlr4-go/antlr/v4 v4.13.0 h1:lxCg3LAv+EUK6t1i0y1V6/SLeUi0eKEKdhQAlS8TVTI=
 github.com/antlr4-go/antlr/v4 v4.13.0/go.mod h1:pfChB/xh/Unjila75QW7+VU4TSnWnnk9UTnmpPaOR2g=
 golang.org/x/exp v0.0.0-20230515195305-f3d0a9c9a5cc h1:mCRnTeVUjcrhlRmO0VK8a6k6Rrf6TF9htwo2pJVSjIU=

--- a/go.sum
+++ b/go.sum
@@ -12,6 +12,10 @@ github.com/JesseCoretta/go-stackage v0.0.2-alpha.9 h1:+tHslb/s8GKasqmT7lZWmYB7Ks
 github.com/JesseCoretta/go-stackage v0.0.2-alpha.9/go.mod h1:x+xxD8I9N7JVURFrjQvLlQAp3AI30egZm7PogZCzB/g=
 github.com/JesseCoretta/go-stackage v0.0.3-alpha.0 h1:svWzvZVVytL6v16nip7ociF/Xr3ON8KCKMoVbI+eWnA=
 github.com/JesseCoretta/go-stackage v0.0.3-alpha.0/go.mod h1:x+xxD8I9N7JVURFrjQvLlQAp3AI30egZm7PogZCzB/g=
+github.com/JesseCoretta/go-stackage v0.0.3-alpha.0.0.20230915073156-fa22d029b913 h1:ilJ+hdIiObZ1P+zhPwDWj6jzriyFo0n2LQ/eKPV8mdY=
+github.com/JesseCoretta/go-stackage v0.0.3-alpha.0.0.20230915073156-fa22d029b913/go.mod h1:x+xxD8I9N7JVURFrjQvLlQAp3AI30egZm7PogZCzB/g=
+github.com/JesseCoretta/go-stackage v0.0.3-alpha.0.0.20230915085653-806fd28c0132 h1:iuTYrRwLCeMRZo/wcMyowdpw1buNWExFd6Dt0dAcR18=
+github.com/JesseCoretta/go-stackage v0.0.3-alpha.0.0.20230915085653-806fd28c0132/go.mod h1:x+xxD8I9N7JVURFrjQvLlQAp3AI30egZm7PogZCzB/g=
 github.com/antlr4-go/antlr/v4 v4.13.0 h1:lxCg3LAv+EUK6t1i0y1V6/SLeUi0eKEKdhQAlS8TVTI=
 github.com/antlr4-go/antlr/v4 v4.13.0/go.mod h1:pfChB/xh/Unjila75QW7+VU4TSnWnnk9UTnmpPaOR2g=
 golang.org/x/exp v0.0.0-20230515195305-f3d0a9c9a5cc h1:mCRnTeVUjcrhlRmO0VK8a6k6Rrf6TF9htwo2pJVSjIU=

--- a/go.sum
+++ b/go.sum
@@ -18,6 +18,8 @@ github.com/JesseCoretta/go-stackage v0.0.3-alpha.0.0.20230915085653-806fd28c0132
 github.com/JesseCoretta/go-stackage v0.0.3-alpha.0.0.20230915085653-806fd28c0132/go.mod h1:x+xxD8I9N7JVURFrjQvLlQAp3AI30egZm7PogZCzB/g=
 github.com/JesseCoretta/go-stackage v0.0.3-alpha.0.0.20230917063119-c5b1c11b1112 h1:Mm/l++4qytP8gidOwlKRh+u9wviKFR0nI3wU2IS60cg=
 github.com/JesseCoretta/go-stackage v0.0.3-alpha.0.0.20230917063119-c5b1c11b1112/go.mod h1:x+xxD8I9N7JVURFrjQvLlQAp3AI30egZm7PogZCzB/g=
+github.com/JesseCoretta/go-stackage v0.0.3-alpha.0.0.20230917071832-d54179314634 h1:q3E7RSLdUA61AXV97tO+otWNWCrMkd6hSygfxbyQERk=
+github.com/JesseCoretta/go-stackage v0.0.3-alpha.0.0.20230917071832-d54179314634/go.mod h1:x+xxD8I9N7JVURFrjQvLlQAp3AI30egZm7PogZCzB/g=
 github.com/antlr4-go/antlr/v4 v4.13.0 h1:lxCg3LAv+EUK6t1i0y1V6/SLeUi0eKEKdhQAlS8TVTI=
 github.com/antlr4-go/antlr/v4 v4.13.0/go.mod h1:pfChB/xh/Unjila75QW7+VU4TSnWnnk9UTnmpPaOR2g=
 golang.org/x/exp v0.0.0-20230515195305-f3d0a9c9a5cc h1:mCRnTeVUjcrhlRmO0VK8a6k6Rrf6TF9htwo2pJVSjIU=

--- a/pb.go
+++ b/pb.go
@@ -238,6 +238,7 @@ func processBindRule(ibrc IBindRuleContext) (r stackage.Condition, err error) {
 	}
 
 	var ct int = ibrc.GetChildCount()
+	r.Init()
 
 	// iterate child components of the bind rule:
 	// keyword, operator, value(s).
@@ -446,6 +447,10 @@ func processBindRules(ctx IBindRulesContext, depth int, oparen bool, boolword ..
 		return
 	}
 	outer = inner
+
+	// Defrag+Reveal
+	outer.Defrag().
+		Reveal()
 
 	return
 }

--- a/pb_test.go
+++ b/pb_test.go
@@ -109,7 +109,7 @@ func TestParseBindRule(t *testing.T) {
 		r, err := ParseBindRule(want)
 		if err != nil {
 			// There was an error ...
-			if idx%2 == 0 || idx == 0 {
+			if idx%2 == 0 {
 				// Valid test should have worked, but did not ...
 				t.Errorf("%s [VALID] failed [idx[%d]::%d/%d]: err:%v\nwant: '%s'\ngot:  '%s'",
 					t.Name(), idx, i, ct, err, want, r)
@@ -197,7 +197,8 @@ package level function. A PermissionBindRule is a statement of the following syn
 	[ disposition (right,...)  WHSP [BindRules]  ; ]
 	 ------------------------   |   -----------   \
 	        Permission          |    BindRules     \
-	                             \                  terminator
+	                            +                   +- terminator
+				     \
 	                              \
 	                          seperator
 

--- a/target.go
+++ b/target.go
@@ -30,6 +30,8 @@ func processTargetRule(itrc ITargetRuleContext) (r stackage.Condition, err error
 		ex RuleExpression
 	)
 
+	r.Init()
+
 	for k := 0; k < ct; k++ {
 		switch tv := itrc.GetChild(k).(type) {
 


### PR DESCRIPTION
## Changes

- Use newer **_development-release_** of [`go-stackage`](https://github.com/JesseCoretta/go-stackage/tree/dev) to test new features -- specifically `Stack.Reveal` and `Stack.Defrag`, each of which can help in performing additional clean-up following the completion of a BindRule[s] parse->stack cycle (see also #1)
- Update `stackage.Condition` references within `pb.go` and `target.go` to pre-initialize the return instance, as is required with newer version of [`go-stackage`](https://github.com/JesseCoretta/go-stackage)